### PR TITLE
Revert "Chore(deps): Bump hashicorp/aws from 5.57.0 to 5.58.0 in /cockroachdb"

### DIFF
--- a/cockroachdb/cockroachdb.tf
+++ b/cockroachdb/cockroachdb.tf
@@ -6,7 +6,7 @@ terraform {
     }
     aws = {
       source  = "hashicorp/aws"
-      version = "5.58.0"
+      version = "5.57.0"
     }
   }
   backend "s3" {


### PR DESCRIPTION
Reverts miyamo2/infra.miyamo.today#92